### PR TITLE
Switched to different host for go-nagios

### DIFF
--- a/cmd/check_logfile/main.go
+++ b/cmd/check_logfile/main.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"github.com/jessevdk/go-flags"
-	"github.com/laziac/go-nagios/nagios"
+	"github.com/nightlyone/go-nagios/nagios"
 	"github.com/nightlyone/checklogfile"
 	"io/ioutil"
 	"os"


### PR DESCRIPTION
The original repository has been deleted together with the account of
its owner. A copy is still available at the new repository with the
same state as the original one so I'm using this from now on.
